### PR TITLE
Fix inconsistent use of tabs and spaces

### DIFF
--- a/src/synthcontrol/syntheticControl.py
+++ b/src/synthcontrol/syntheticControl.py
@@ -61,7 +61,7 @@ class RobustSyntheticControl(object):
     #                               If longer than 1, then the most recent point will be used (for each series)
     def predict(self, otherKeysToSeriesDFNew):
         prediction = np.dot(self.model.weights, otherKeysToSeriesDFNew[self.otherSeriesKeysArray].T)
-    	return prediction
+        return prediction
 
     # return the synthetic control weights
     def getControl():


### PR DESCRIPTION
Replace the tab character in the indentation, which caused the following exception:

```python
%run testScriptSynthControlALS.py
  File "../..\tslib\src\synthcontrol\syntheticControl.py", line 64
    return prediction
                     ^
TabError: inconsistent use of tabs and spaces in indentation
```